### PR TITLE
Updates docs to include reference to signature check

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Parses user messages sent from Kik's server. Use the [.incoming()](#Bot+incoming
 | [options.receiveReadReceipts] | <code>boolean</code> |  |
 | [options.receiveDeliveryReceipts] | <code>boolean</code> |  |
 | [options.receiveIsTyping] | <code>boolean</code> |  |
+| [options.skipSignatureCheck] | <code>boolean</code> | Verify the authenticity of inbound requests |
 
 <a name="Bot+use"></a>
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Parses user messages sent from Kik's server. Use the [.incoming()](#Bot+incoming
 | [options.receiveReadReceipts] | <code>boolean</code> |  |
 | [options.receiveDeliveryReceipts] | <code>boolean</code> |  |
 | [options.receiveIsTyping] | <code>boolean</code> |  |
-| [options.skipSignatureCheck] | <code>boolean</code> | Verify the authenticity of inbound requests |
+| [options.skipSignatureCheck] | <code>boolean</code> | Verify the authenticity of inbound requests. **For testing only, do not disable for a bot in production.** |
 
 <a name="Bot+use"></a>
 


### PR DESCRIPTION
Documentation for `isSignatureValid` and the corresponding config key `skipSignatureCheck` are missing. 

On a side note, the signature check should probably be enabled by default.