### PR TITLE
Fix promise chaining

### DIFF
--- a/index.js
+++ b/index.js
@@ -641,7 +641,7 @@ class Bot {
                 if (!this.pendingFlush) {
                     this.pendingFlush = true;
 
-                    process.nextTick(() => fulfill(this.flush(true)));
+                    process.nextTick(() => this.flush(true).then(fulfill, reject));
                 }
 
                 return;
@@ -686,7 +686,7 @@ class Bot {
                 }
             });
 
-            fulfill(promises);
+            Promise.all(promises).then(fulfill, reject);
         });
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kikinteractive/kik",
-    "version": "2.0.3",
+    "version": "2.0.5",
     "description": "Kik bot API for Node.js",
     "main": "index.js",
     "engines": {


### PR DESCRIPTION
Script that currently fails on master:
```javascript
const Bot = require('./index');

const bot = new Bot({
    username: process.env.BOT_USERNAME,
    apiKey: process.env.BOT_API_KEY,
    baseUrl: process.env.BOT_URL
});

bot.send('hello there', 'some_username').then(() => {
    console.log('messages considered to be sent');
    process.exit(0);
}, (err) => {
    console.error(err);
    process.exit(1);
});
```

Basically, when using `new Promise((resolve, reject) => {})`, you can't resolve with another promise, otherwise it will actually resolve instead of chaining the new promise.