### PR TITLE
Added setMention() to Message class

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ Object that stores a specific message that can be sent to/received from a user. 
         * [.setMuted(muted)](#Message+setMuted) ⇒ <code>[Message](#Message)</code>
         * [.setAutoplay(autoplay)](#Message+setAutoplay) ⇒ <code>[Message](#Message)</code>
         * [.setNoSave(noSave)](#Message+setNoSave) ⇒ <code>[Message](#Message)</code>
+        * [.setMention(noSave)](#Message+setMention) ⇒ <code>[Message](#Message)</code>
 
 <a name="Message+from"></a>
 
@@ -968,6 +969,17 @@ See https://dev.kik.com/#/docs/messaging#keyboards
 | Param | Type |
 | --- | --- |
 | noSave | <code>boolean</code> |
+
+<a name="Message.text"></a>
+
+<a name="Message+setNoSave"></a>
+
+### message.setMention(mention) ⇒ <code>[Message](#Message)</code>
+**Kind**: instance method of <code>[Message](#Message)</code>  
+
+| Param | Type |
+| --- | --- |
+| mention | <code>string</code> |
 
 <a name="Message.text"></a>
 

--- a/lib/message.js
+++ b/lib/message.js
@@ -261,6 +261,10 @@ class Message {
             json.keyboards = state.keyboards;
         }
 
+        if (state.mention) {
+            json.mention = '' + state.mention;
+        }
+
         return json;
     }
 
@@ -773,6 +777,15 @@ class Message {
      */
     setNoSave(noSave) {
         this._state.noSave = noSave;
+        return this;
+    }
+
+    /**
+     *  @param {string} mention
+     *  @return {Message}
+     */
+    setMention(mention) {
+        this._state.mention = mention;
         return this;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kikinteractive/kik",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "description": "Kik bot API for Node.js",
     "main": "index.js",
     "engines": {

--- a/test/test-message-construction.js
+++ b/test/test-message-construction.js
@@ -195,6 +195,18 @@ describe('Message construction', () => {
         assert.deepEqual(message.toJSON(), expected);
     });
 
+    it('with a mention', () => {
+        const message = Bot.Message.text('body')
+            .setMention('someotherbot');
+        const expected = {
+            type: 'text',
+            body: 'body',
+            mention: 'someotherbot'
+        };
+
+        assert.deepEqual(message.toJSON(), expected);
+    });
+
     it('of is typing', () => {
         const message = Bot.Message.isTyping(true);
         const expected = {


### PR DESCRIPTION
@mproberts 
Missing support for bot-to-bot conversations. This PR fixes that.