### PR TITLE
[yarn] Changing strict engine version to minimal requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Kik bot API for Node.js",
     "main": "index.js",
     "engines": {
-        "node": "5.x.x",
+        "node": ">=5",
         "npm": "3.x.x"
     },
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "engines": {
         "node": ">=5",
-        "npm": "3.x.x"
+        "npm": ">=3"
     },
     "keywords": [
         "kik",


### PR DESCRIPTION
The engine version in package.json is currently locked to 5.x.x.
This could be a problem, for example, using yarn to install the package when running node 6 or above leads to : 
```
error @kikinteractive/kik@2.0.11: The engine "node" is incompatible with this module. Expected version "5.x.x".
```
