### PR TITLE
Support metadata on all keyboard keys

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -2,14 +2,15 @@
 
 class Response {
 
-    static text(body) {
+    static text(body, metadata) {
         return {
             type: 'text',
-            body: '' + body
+            body: '' + body,
+            metadata: metadata
         };
     }
 
-    static friendPicker(body, min, max, preselected) {
+    static friendPicker(body, min, max, preselected, metadata) {
         const response = {
             type: 'friend-picker'
         };
@@ -27,6 +28,10 @@ class Response {
 
         if (preselected) {
             response.preselected = preselected;
+        }
+        
+        if (metadata) {
+            response.metadata = metadata;
         }
 
         return response;


### PR DESCRIPTION
Adds new `metadata` parameter to the end of the `text` and `friendPicker` helper functions.
The value gets directly passed to the response object, just like with the `picture` function.
Maybe it should be turned into a string

#53 